### PR TITLE
Improve RSpec matcher

### DIFF
--- a/lib/parslet/rig/rspec.rb
+++ b/lib/parslet/rig/rspec.rb
@@ -1,24 +1,39 @@
 RSpec::Matchers.define(:parse) do |input|
-  chain(:as) { |as| @as = as }
 
   match do |parser|
     begin
       @result = parser.parse(input)
-      @as == @result or @as.nil?
+      @block ? @block.call(@result)\
+             : (@as == @result || @as.nil?)
     rescue Parslet::ParseFailed
       false
     end
   end
 
   failure_message_for_should do |is|
-    "expected " << (@result ?
-      "output of parsing #{input.inspect} with #{is.inspect} to equal #{@as.inspect}, but was #{@result.inspect}" :
-      "#{is.inspect} to be able to parse #{input.inspect}")
+    if @block
+      "expected output of parsing #{input.inspect} with #{is.inspect} to meet block conditions, but it didn't"
+    else
+      "expected " << (@result ?
+        "output of parsing #{input.inspect} with #{is.inspect} to equal #{@as.inspect}, but was #{@result.inspect}" :
+        "#{is.inspect} to be able to parse #{input.inspect}")
+    end
   end
 
   failure_message_for_should_not do |is|
-    "expected " << (@as ?
-      "output of parsing #{input.inspect} with #{is.inspect} not to equal #{@as.inspect}" :
-      "#{is.inspect} to not parse #{input.inspect}, but it did")
+    if @block
+      "expected output of parsing #{input.inspect} with #{is.inspect} not to meet block conditions, but it did"
+    else
+      "expected " << (@as ?
+        "output of parsing #{input.inspect} with #{is.inspect} not to equal #{@as.inspect}" :
+        "#{is.inspect} to not parse #{input.inspect}, but it did")
+    end
   end
+
+  def as(expected_output = nil, &block)
+    @as = expected_output
+    @block = block
+    self
+  end
+
 end

--- a/spec/parslet/rig/rspec_spec.rb
+++ b/spec/parslet/rig/rspec_spec.rb
@@ -14,6 +14,13 @@ describe 'rspec integration' do
   it { str('foo').as(:bar).should parse('foo').as({:bar => 'foo'}) }
   it { str('foo').as(:bar).should_not parse('foo').as({:b => 'f'}) }
 
+  it 'accepts a block to assert more specific details about the parsing output' do
+    str('foo').as(:bar).should(parse('foo').as { |output|
+      output.should have_key(:bar)
+      output.values.first.should == 'foo'
+    })
+  end
+
   # it { str('foo').should parse('foo').as('bar') }
   # it { str('foo').should parse('food') }
   # it { str('foo').should_not parse('foo').as('foo') }


### PR DESCRIPTION
RSpec matcher :as chain now accepts a block. This allows for partial assertions on the output, rather than just equality. An example would be:

```
str('foo').as(:bar).should(parse('foo').as { |output|
  output.should have_key(:bar)
  output.values.first.should == 'foo'
})
```
