### PR TITLE
Rspec transform matcher

### DIFF
--- a/spec/parslet/rig/rspec.rb
+++ b/spec/parslet/rig/rspec.rb
@@ -1,0 +1,81 @@
+RSpec::Matchers.define(:parse) do |input, opts|
+  match do |parser|
+    begin
+      @result = parser.parse(input)
+      @block ? 
+        @block.call(@result) : 
+        (@as == @result || @as.nil?)
+    rescue Parslet::ParseFailed
+      @trace = parser.error_tree.ascii_tree if opts && opts[:trace]
+      false
+    end
+  end
+
+  failure_message_for_should do |is|
+    if @block
+      "expected output of parsing #{input.inspect}" <<
+      " with #{is.inspect} to meet block conditions, but it didn't"
+    else
+      "expected " << 
+        (@as ? 
+          "output of parsing #{input.inspect}"<<
+          " with #{is.inspect} to equal #{@as.inspect}, but was #{@result.inspect}" : 
+          "#{is.inspect} to be able to parse #{input.inspect}") << 
+        (@trace ? 
+          "\n"+@trace : 
+          '')
+    end
+  end
+
+  failure_message_for_should_not do |is|
+    if @block
+      "expected output of parsing #{input.inspect} with #{is.inspect} not to meet block conditions, but it did"
+    else
+      "expected " << 
+        (@as ? 
+          "output of parsing #{input.inspect}"<<
+          " with #{is.inspect} not to equal #{@as.inspect}" :
+          
+          "#{is.inspect} to not parse #{input.inspect}, but it did")
+    end
+  end
+
+  def as(expected_output = nil, &block)
+    @as = expected_output
+    @block = block
+    self
+  end
+end
+
+RSpec::Matchers.define(:apply) do |input|
+  match do |transformer|
+    begin
+      @result = transformer.apply(input)
+      @as == @result or @as.nil?
+    rescue Exception => e
+      @trace = "#{e.message} #{e.backtrace.inspect}"
+      false
+    end
+  end
+
+  failure_message_for_should do |is|
+    (@as ? 
+    "expected " << 
+      "output of transforming #{input.inspect}" <<
+      " with #{is.inspect} to equal #{@as.inspect}, but was #{@result.inspect}" :
+      "#{is.inspect} to be able to transform #{input.inspect}") << 
+      (@trace ? 
+        "\n"+@trace : 
+        '')
+  end
+
+  failure_message_for_should_not do |is|
+    "expected " << 
+      (@as ? 
+        "output of transforming #{input.inspect}"<<
+        " with #{is.inspect} not to equal #{@as.inspect}" :
+        
+        "#{is.inspect} to not transform #{input.inspect}, but it did")
+  end
+end
+


### PR DESCRIPTION
Added an RSpec::Matcher for transformer classes following the pattern shown in the documentation of defining and #apply method that delegates to an instance of Parslet::Transform#apply.  

The matcher takes a transformer in its block and matches on :apply.  This lets users of Parslet write RSpec tests for transformations very much like those for #parse cases.  
An example of such a test:

```
describe ComposerTransformer do
 let(:transformer) { ComposerTransformer.new }
 context 'kw_note_stmt' do
    stmt = 'note "note 1"'
    in_stmt = stmt + sp + eol
    expected = stmt + sp + blk_open + eol
    it 'should transform ' + in_stmt + ' to' + expected do
      parse_tree = ComposerParser.new.parse(in_stmt)
      transformer.should apply(parse_tree)
      transformer.apply(parse_tree).should == expected
   end 
  end
end
```
