### PR TITLE
index page: absnt? -> absent?

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
   parser =  str('"') &gt;&gt; 
             (
               str('\\') &gt;&gt; any |
-              str('"').absnt? &gt;&gt; any
+              str('"').absent? &gt;&gt; any
             ).repeat.as(:string) &gt;&gt; 
             str('"')
 


### PR DESCRIPTION
Since it's more obvious and it seems `absnt?` is deprecated (https://github.com/kschiess/parslet/issues/28).
