### PR TITLE
Optimizes multibyte parsing

### DIFF
--- a/lib/parslet/source/line_cache.rb
+++ b/lib/parslet/source/line_cache.rb
@@ -32,22 +32,23 @@ class Parslet::Source
 
     def scan_for_line_endings(start_pos, buf)
       return unless buf
-      return unless buf.index("\n")
-      cur = -1
 
-      # If we have already read part or all of buf, we already know about
-      # line ends in that portion. remove it and correct cur (search index)
+      buf = StringScanner.new(buf)
+      return unless buf.exist?(/\n/)
+
+      ## If we have already read part or all of buf, we already know about
+      ## line ends in that portion. remove it and correct cur (search index)
       if @last_line_end && start_pos < @last_line_end
         # Let's not search the range from start_pos to last_line_end again.
-        cur = @last_line_end - start_pos -1
+        buf.pos = @last_line_end - start_pos
       end
 
-      # Scan the string for line endings; store the positions of all endings
-      # in @line_ends. 
-      while buf && cur = buf.index("\n", cur+1)
-        @last_line_end = (start_pos + cur+1)
+      ## Scan the string for line endings; store the positions of all endings
+      ## in @line_ends. 
+      while buf.skip_until(/\n/)
+        @last_line_end = start_pos + buf.pos
         @line_ends << @last_line_end
-      end 
+      end
     end
   end
 

--- a/spec/parslet/source/line_cache_spec.rb
+++ b/spec/parslet/source/line_cache_spec.rb
@@ -37,3 +37,38 @@ describe Parslet::Source::RangeSearch do
     end
   end
 end
+
+describe Parslet::Source::LineCache do
+  describe "<- scan_for_line_endings" do
+    context "calculating the line_and_columns" do
+      let(:str) { "foo\nbar\nbazd" }
+
+      it "should return the first line if we have no line ends" do
+        subject.scan_for_line_endings(0, nil)
+        subject.line_and_column(3).should == [1, 4]
+
+        subject.scan_for_line_endings(0, "")
+        subject.line_and_column(5).should == [1, 6]
+      end
+
+      it "should find the right line starting from pos 0" do
+        subject.scan_for_line_endings(0, str)
+        subject.line_and_column(5).should == [2, 2]
+        subject.line_and_column(9).should == [3, 2]
+      end
+
+      it "should find the right line starting from pos 5" do
+        subject.scan_for_line_endings(5, str)
+        subject.line_and_column(11).should == [2, 3]
+      end
+
+      it "should find the right line if scannning the string multiple times" do
+        subject.scan_for_line_endings(0, str)
+        subject.scan_for_line_endings(0, "#{str}\nthe quick\nbrown fox")
+        subject.line_and_column(10).should == [3,3]
+        subject.line_and_column(24).should == [5,2]
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
String#index and String#[] has terrible performance, O(n),when multibyte
characters are included in the string. So this uses the stdlib
StringScanner and uses regexp for all matching.

Relevant links:
- https://bugs.ruby-lang.org/issues/8129
- #73 - https://github.com/kschiess/parslet/issues/73

I created specs for LineCache first before refactoring.
