### PR TITLE
in Contribute, say IRC server is Freenode

### DIFF
--- a/website/source/contribute.html.textile
+++ b/website/source/contribute.html.textile
@@ -8,7 +8,7 @@ the day for you? Please contribute! Find the code on
 
 h2. Contact
 
-Join us on IRC in #parslet. 
+Join us on IRC in #parslet on irc.freenode.net.
 
 Discussion and patches (or the odd cry for 'Help! How can I parse X?') should
 go to our mailing list at


### PR DESCRIPTION
Someone wanted this information two years ago on https://github.com/kschiess/parslet/issues/12 , and today I, too, wanted this information.

I’m not an expert at IRC, so if calling the server “Freenode” is better than “irc.freenode.net” because everybody knows Freenode’s address, feel free to change that.
