### PR TITLE
clarified “transmogrify” in website

### DIFF
--- a/website/source/documentation.html.textile
+++ b/website/source/documentation.html.textile
@@ -20,8 +20,8 @@ of parslet. Especially:
 * "Overview":overview.html explains parslet's goals and gives you a bigger
   picture.
 * Using "Parslet::Parser":parser.html to *write parsers*.
-* Using "Parslet::Transform":transform.html to *transmogrify your intermediary
-  trees*.
+* Using "Parslet::Transform":transform.html to *turn your intermediary
+  trees into something useful*.
 * "Tricks":tricks.html for common situations.
 
 *Presentations*


### PR DESCRIPTION
Rather than explaining “transform” by using a synonym for it, this explanation actually clarifies and elaborates on the meaning.
