### PR TITLE
fix DEPRECATION warning from RSpec.

### DIFF
--- a/spec/acceptance/regression_spec.rb
+++ b/spec/acceptance/regression_spec.rb
@@ -87,7 +87,7 @@ describe "Regressions from real examples" do
         lambda {
           instance.parse('((()))')
           instance.parse('(((())))')
-        }.should_not raise_error(Parslet::ParseFailed)
+        }.should_not raise_error
       end 
     end
     context "expression '(())'" do

--- a/spec/parslet/convenience_spec.rb
+++ b/spec/parslet/convenience_spec.rb
@@ -18,10 +18,10 @@ describe 'parslet/convenience' do
         parser.should_receive(:puts)
       end
       it 'should exist' do
-        lambda { parser.parse_with_debug('anything') }.should_not raise_error(NoMethodError)
+        lambda { parser.parse_with_debug('anything') }.should_not raise_error
       end
       it 'should catch ParseFailed exceptions' do
-        lambda { parser.parse_with_debug('bar') }.should_not raise_error(Parslet::ParseFailed)
+        lambda { parser.parse_with_debug('bar') }.should_not raise_error
       end
       it 'should parse correct input like #parse' do
         lambda { parser.parse_with_debug('foo') }.should_not raise_error


### PR DESCRIPTION
I began to use parslet, it looks really cool.
Unfortunately, it doesn't pass spec well. I got no failure but some warnings with running `rspec` command:

``` log
Run options: exclude {:ruby=>#<Proc:./spec/spec_helper.rb:13>}
...........................................DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error` (with no args) instead. Called from /home/tadashi/git/parslet/spec/acceptance/regression_spec.rb:87:in `block (4 levels) in <top (required)>'.
.......................................................................................................................................................................DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error` (with no args) instead. Called from /home/tadashi/git/parslet/spec/parslet/convenience_spec.rb:21:in `block (4 levels) in <top (required)>'.
.DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error` (with no args) instead. Called from /home/tadashi/git/parslet/spec/parslet/convenience_spec.rb:24:in `block (4 levels) in <top (required)>'.
...................................................................................................................................................................................................

Finished in 5.08 seconds
406 examples, 0 failures
```

I agree with the warnings because it seems that raising nothing is correct spec, so I removed class specification.

My rspec version is:

```
$ rspec --version
2.14.6
```
