### PR TITLE
Fix bug where Array was returned, not Expression

### DIFF
--- a/lib/parslet/accelerator.rb
+++ b/lib/parslet/accelerator.rb
@@ -77,6 +77,7 @@ module Parslet::Accelerator
     def join_or_new tag, other_expr
       if type == tag
         @args << other_expr
+        self
       else
         Expression.new(tag, self, other_expr)
       end


### PR DESCRIPTION
Hi, I'm playing around with accelerators and noticed that an expression like the following becomes an array by accident:

```
expression = a.str('\\') >> a.any |
  a.str("''") |
  a.str("'").absent? >> a.any
```

`expression` is an array (the value of @args) when it should be an Expression.
