### PR TITLE
Update matcher protocol in parslet/rig/rspec

### DIFF
--- a/lib/parslet/rig/rspec.rb
+++ b/lib/parslet/rig/rspec.rb
@@ -1,6 +1,14 @@
 RSpec::Matchers.define(:parse) do |input, opts|
   as = block = nil
   result = trace = nil
+
+  unless self.respond_to? :failure_message # if RSpec 2.x
+    class << self
+      alias_method :failure_message, :failure_message_for_should
+      alias_method :failure_message_when_negated, :failure_message_for_should_not
+    end
+  end
+
   match do |parser|
     begin
       result = parser.parse(input)
@@ -13,7 +21,7 @@ RSpec::Matchers.define(:parse) do |input, opts|
     end
   end
 
-  failure_message_for_should do |is|
+  failure_message do |is|
     if block
       "expected output of parsing #{input.inspect}" <<
       " with #{is.inspect} to meet block conditions, but it didn't"
@@ -29,7 +37,7 @@ RSpec::Matchers.define(:parse) do |input, opts|
     end
   end
 
-  failure_message_for_should_not do |is|
+  failure_message_when_negated do |is|
     if block
       "expected output of parsing #{input.inspect} with #{is.inspect} not to meet block conditions, but it did"
     else


### PR DESCRIPTION
http://myronmars.to/n/dev-blog/2014/02/rspec-2-99-and-3-0-beta-2-have-been-released

> Update matcher protocol and custom matcher DSL to better align with the
> newer expect syntax. If you want your matchers to maintain compatibility
> with multiple versions of RSpec, you can alias the new names to the old.
> (Myron Marston)
> - failure_message_for_should => failure_message
> - failure_message_for_should_not => failure_message_when_negated
> - match_for_should => match
> - match_for_should_not => match_when_negated

Sorry, no tests for RSpec 3 integration. I'm eager to add them but I'm unsure how.

It's possible to check in two gemfiles with different Rspec versions into project and so that Travis runs against both of them. [Example](https://github.com/collectiveidea/json_spec/blob/master/.travis.yml). But maybe that's overkill? It makes tests 2x longer (they're pretty quick, though). [Capybara supports both RSpec versions](https://github.com/jnicklas/capybara/blob/master/lib/capybara/rspec/matchers.rb#L65), but CI checks it against 2.x only.
