### PR TITLE
offset now works correct, by replacing #pos to #charpos in source.rb:41

### DIFF
--- a/lib/parslet/source.rb
+++ b/lib/parslet/source.rb
@@ -38,7 +38,7 @@ module Parslet
     # input. 
     #
     def consume(n)
-      original_pos = @str.pos
+      original_pos = @str.charpos
       slice_str = @str.scan(@re_cache[n])
       slice = Parslet::Slice.new(
         slice_str,


### PR DESCRIPTION
thats all ;)
# charpos counts multibyte (nonASCII) chars as one,

whereas #pos counts as two
offset works now fine
