### PR TITLE
Detect infinite loop and raise exception

### DIFF
--- a/lib/parslet/atoms/repetition.rb
+++ b/lib/parslet/atoms/repetition.rb
@@ -36,7 +36,11 @@ class Parslet::Atoms::Repetition < Parslet::Atoms::Base
 
       break_on = value
       break unless success
-
+      
+      if !max && source.pos == start_pos        
+        raise "Grammar contains an infinite loop applying '#{self}' at char position #{source.pos.charpos}\n...#{source.pos.context}<-- here"  
+      end
+      
       occ += 1
       accum << value
       

--- a/lib/parslet/position.rb
+++ b/lib/parslet/position.rb
@@ -18,4 +18,9 @@ class Parslet::Position
   def <=> b
     self.bytepos <=> b.bytepos
   end
+  
+  def context
+    slice = @string.byteslice(0,@bytepos)
+    slice[-20..-1] || slice
+  end
 end


### PR DESCRIPTION
This seems to work well. I don't know how much unit testing etc. you would like me to do to show this works. .. but I used it to debug the ruby-in-ruby\crystal failing_tests we were discussing on the mailing list. 

I added  a helper to Position to let me output the preceding 20 characters. I'm sure you have a better way to show parser context when throwing exception, but this was useful for me.  