### PR TITLE
Node Transformer data modules

### DIFF
--- a/lib/parslet/transform.rb
+++ b/lib/parslet/transform.rb
@@ -134,12 +134,14 @@ class Parslet::Transform
     end
   end
   
-  def initialize(&block) 
+  def initialize(data_module=nil, &block)
     @rules = []
     
     if block
       instance_eval(&block)
     end
+
+    @data_module = data_module || {}
   end
   
   # Defines a rule to be applied whenever apply is called on a tree. A rule
@@ -187,6 +189,8 @@ class Parslet::Transform
   #   t.call_on_match(:a => :b) { |d| d[:a] }
   #
   def call_on_match(bindings, block)
+    bindings.merge! @data_module
+
     if block
       if block.arity == 1
         return block.call(bindings)

--- a/spec/parslet/transform_spec.rb
+++ b/spec/parslet/transform_spec.rb
@@ -55,6 +55,19 @@ describe Parslet::Transform do
           Bi.new('c', 'f')
       end 
     end
+    describe "data_module" do
+      let(:data_module) { {'data_module_method' => -> {'foobar'} } }
+      let(:transform) { Parslet::Transform.new(data_module) }
+      context "given simple(:x) => (eval 'data_module_method').call" do
+        before(:each) do
+          transform.rule(simple(:x)) { (eval 'data_module_method').call }
+        end
+
+        it "should call data_module_method from the data_module" do
+          transform.apply(['data_module_method']).should == ['foobar']
+        end
+      end
+    end
   end
   describe "dsl construction" do
     let(:transform) { Parslet::Transform.new do


### PR DESCRIPTION
Node interpreter now takes an optional data module. The optional data module can supply helper methods to parslet transformers. An example use case would be needing to make an external API call.

We're using a monkey patched version of Parslet at the moment because we need to reference external plugin dependancies. These look like https://github.com/alphagov/smart-answers/blob/master/lib/smartdown_plugins/animal-example-simple/build_time.rb In this example we use the return value of pokemon_regions to build an element using Parslet::Transform. In our DSL we have a notion of references to external 'build_time' functions. When the transformer is run the external 'build_time' functions are available and can return their output to then be be used to transform them into objects.

I made this pull request to hopefully demonstrate this behaviour to you and perhaps to make this behaviour part of Parslet. If you agree this is a sensible approach. If not we'd love some pointers on a better way to do this.
