### PR TITLE
Fix a typo.

### DIFF
--- a/parser.html
+++ b/parser.html
@@ -234,7 +234,7 @@ tree (assuming a successful parse) on the right:</p>
 <p>Sometimes a parser needs to match against something that was already matched
 against. Think about Ruby heredocs for example:</p>
 <pre class="sh_ruby"><code>
-  str = &lt;-HERE
+  str = &lt;&lt;-HERE
     This is part of the heredoc.
   HERE
 </code></pre>


### PR DESCRIPTION
In ruby, heredoc can use `<<` or `<<-`.
see http://en.wikipedia.org/wiki/Here_document#Ruby