### PR TITLE
fix issue that stops opal parsing

### DIFF
--- a/lib/parslet/context.rb
+++ b/lib/parslet/context.rb
@@ -21,7 +21,7 @@ class Parslet::Context < BlankSlate
   include Parslet
   
   def meta_def(name, &body)
-    metaclass = class <<self; self; end
+    metaclass = class << self; self; end
 
     metaclass.send(:define_method, name, &body)
   end

--- a/lib/parslet/parser.rb
+++ b/lib/parslet/parser.rb
@@ -30,7 +30,7 @@
 class Parslet::Parser < Parslet::Atoms::Base
   include Parslet
 
-  class <<self # class methods
+  class << self # class methods
     # Define the parsers #root function. This is the place where you start 
     # parsing; if you have a rule for 'file' that describes what should be 
     # in a file, this would be your root declaration: 


### PR DESCRIPTION
As the title says, this isn't really a bug, or rather it is a bug, but in opal, not parslet. 
And this fix doesn't unfortunately even get parslet to work in opal.
But at least it loads, and i filed issues for the scanner functions that would be needed.
Currently i have everything but the parsing working in opal, so it would be nice one day to get the 
whole thing working.