### PR TITLE
Include parslet.gemspec and spec directory

### DIFF
--- a/parslet.gemspec
+++ b/parslet.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.authors = ['Kaspar Schiess']
   s.email = 'kaspar.schiess@absurd.li'
   s.extra_rdoc_files = ['README']
-  s.files = %w(HISTORY.txt LICENSE Rakefile README) + Dir.glob("{lib,example}/**/*")
+  s.files = %w(HISTORY.txt LICENSE Rakefile README parslet.gemspec) + Dir.glob("{lib,spec,example}/**/*")
   s.homepage = 'http://kschiess.github.io/parslet'
   s.license = 'MIT'
   s.rdoc_options = ['--main', 'README']


### PR DESCRIPTION
if you include parslet.gemspec and spec directory it is better for Debian.
If this the gemspec and the sepc directory is included into the gem we
(at debian) could run the unit tests after build time.

@kschiess atfer merging this PR, could you please release and upload a new version to rubygems?

Thanks!