### PR TITLE
make the rspec rig work for rspec 2.99

### DIFF
--- a/lib/parslet/rig/rspec.rb
+++ b/lib/parslet/rig/rspec.rb
@@ -2,13 +2,6 @@ RSpec::Matchers.define(:parse) do |input, opts|
   as = block = nil
   result = trace = nil
 
-  unless self.respond_to? :failure_message # if RSpec 2.x
-    class << self
-      alias_method :failure_message, :failure_message_for_should
-      alias_method :failure_message_when_negated, :failure_message_for_should_not
-    end
-  end
-
   match do |parser|
     begin
       result = parser.parse(input)
@@ -21,7 +14,7 @@ RSpec::Matchers.define(:parse) do |input, opts|
     end
   end
 
-  failure_message do |is|
+  public_send(respond_to?(:failure_message) ? :failure_message : :failure_message_for_should) do |is|
     if block
       "expected output of parsing #{input.inspect}" <<
       " with #{is.inspect} to meet block conditions, but it didn't"
@@ -37,7 +30,7 @@ RSpec::Matchers.define(:parse) do |input, opts|
     end
   end
 
-  failure_message_when_negated do |is|
+  public_send(respond_to?(:failure_message_when_negated) ? :failure_message_when_negated : :failure_message_for_should_not) do |is|
     if block
       "expected output of parsing #{input.inspect} with #{is.inspect} not to meet block conditions, but it did"
     else


### PR DESCRIPTION
Hello!

Thanks for this wonderful project

I'm currently upgrading my app from RSpec 2.14 to the latest. [The upgrade guide](https://relishapp.com/rspec/docs/upgrade) recommends first upgrading to 2.99, then resolving all deprecation warnings, and then upgrading to 3.

Strangely, the rspec rig works great on 2.14 and 3.3, but fails on 2.99 with:

```
NameError:
  undefined method `failure_message_for_should' for class `Class'
```

* here's a small project demonstrating the problem with the latest parslet and RSpec 2.99: https://github.com/maxjacobson/parslet_failure_demo
* here's a branch demonstrating that this patch works on RSpec 2.14 https://github.com/maxjacobson/parslet_failure_demo/tree/rspec-2.14
* here's a branch demonstrating the patch works with RSpec 2.99 https://github.com/maxjacobson/parslet_failure_demo/tree/rspec-2.99
* here's a branch demonstrating the patch works with RSpec 3.3 https://github.com/maxjacobson/parslet_failure_demo/tree/rspec-3.3