### PR TITLE
Resolve an RSpec deprecation warning

### DIFF
--- a/spec/parslet/slice_spec.rb
+++ b/spec/parslet/slice_spec.rb
@@ -112,7 +112,7 @@ describe Parslet::Slice do
           s.to_i.should == 1234
         end 
         it "should fail when Integer would fail on a string" do
-          lambda { Integer(slice) }.should raise_error
+          lambda { Integer(slice) }.should raise_error(ArgumentError, /invalid value/)
         end 
         it "should turn into zero when a string would" do
           slice.to_i.should == 0


### PR DESCRIPTION
When asserting an error will be raised, it's nice to specify which