### PR TITLE
Replace BlankSlate with BasicObject

### DIFF
--- a/experiments/optimizer.rb
+++ b/experiments/optimizer.rb
@@ -5,7 +5,6 @@ $:.unshift File.dirname(__FILE__) + "/../lib"
 require 'parslet'
 require 'parslet/atoms/visitor'
 require 'parslet/convenience'
-require 'blankslate'
 
 class ErbParser < Parslet::Parser
   rule(:ruby) { (str('%>').absent? >> any).repeat.as(:ruby) }
@@ -160,7 +159,7 @@ class Parslet::Optimizer
       @expression, @replacement = expression, replacement
     end
 
-    class Context < BlankSlate
+    class Context
       def initialize(bindings)
         @bindings = bindings
       end

--- a/lib/parslet/context.rb
+++ b/lib/parslet/context.rb
@@ -1,5 +1,3 @@
-require 'blankslate'
-
 # Provides a context for tree transformations to run in. The context allows
 # accessing each of the bindings in the bindings hash as local method.
 #
@@ -11,24 +9,12 @@ require 'blankslate'
 #   end
 #
 # @api private
-class Parslet::Context < BlankSlate
-  reveal :methods
-  reveal :respond_to?
-  reveal :inspect
-  reveal :to_s
-  reveal :instance_variable_set
-
+class Parslet::Context
   include Parslet
-  
-  def meta_def(name, &body)
-    metaclass = class << self; self; end
 
-    metaclass.send(:define_method, name, &body)
-  end
-  
   def initialize(bindings)
     bindings.each do |key, value|
-      meta_def(key.to_sym) { value }
+      singleton_class.send(:define_method, key) { value }
       instance_variable_set("@#{key}", value)
     end
   end

--- a/parslet.gemspec
+++ b/parslet.gemspec
@@ -12,7 +12,5 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.rdoc_options = ['--main', 'README']
   s.require_paths = ['lib']
-  s.summary = 'Parser construction library with great error reporting in Ruby.'  
-  
-  s.add_dependency 'blankslate', '>= 2.0', '<= 4.0'
+  s.summary = 'Parser construction library with great error reporting in Ruby.'
 end

--- a/spec/parslet/atoms_spec.rb
+++ b/spec/parslet/atoms_spec.rb
@@ -225,7 +225,7 @@ describe Parslet do
     
     it "should not loop infinitely" do
       lambda {
-        timeout(1) { parslet.parse('bar') }
+        Timeout.timeout(1) { parslet.parse('bar') }
       }.should raise_error(Parslet::ParseFailed)
     end 
   end

--- a/spec/parslet/transform/context_spec.rb
+++ b/spec/parslet/transform/context_spec.rb
@@ -9,22 +9,6 @@ describe Parslet::Context do
     context(:a => 'value').instance_eval { a }.
       should == 'value'
   end
-  describe 'when a method in BlankSlate is inherited from the environment somehow' do
-    before(:each) { BlankSlate.send(:define_method, :a) { 'c' } }
-    after(:each) { BlankSlate.send(:undef_method, :a) }
-    
-    it "masks what is already on blank slate" do
-      context(:a => 'b').instance_eval { a }.
-        should == 'b'
-    end  
-  end
-  it "should not reveal define_singleton_method for all users of blankslate, just for us" do
-    expect {
-      BlankSlate.new.instance_eval {
-        define_singleton_method(:foo) { 'foo' }
-      }
-    }.to raise_error(NoMethodError)
-  end 
   it "one contexts variables aren't the next ones" do
     ca = context(:a => 'b')
     cb = context(:b => 'c')


### PR DESCRIPTION
Hello,

I faced with a weird error when I tried to use parslet with this gem https://github.com/txus/kleisli (it is dry-types dependency). I did some research and found that the issue is already resolved in master branch (https://github.com/txus/kleisli/pull/17). 

Anyway, I decided that blankslate is not required anymore and replaced it with equivalent BasicObject ancestor.

It would not be necessary but I think that using #method_added is really dark magic and we should avoid it as much as we can. Moreover blankslate adds hooks to Kernel, Object and Module classes (see https://github.com/masover/blankslate/blob/master/lib/blankslate.rb#L62) and it's really really bad.

I tested my changes on ruby 2.0 and higher and all specs passed. I failed to compile 1.9.3 on my machine but I expect that tests would fail because there were some changes about binding methods in ruby 2.0. In that case you could drop 1.9 support but this decision is up to you. You are free to merge PR at anytime you want (=