### PR TITLE
Add the ability to map over parse results

### DIFF
--- a/lib/parslet/atoms.rb
+++ b/lib/parslet/atoms.rb
@@ -31,5 +31,6 @@ module Parslet::Atoms
   require 'parslet/atoms/dynamic'
   require 'parslet/atoms/scope'
   require 'parslet/atoms/infix'
+  require 'parslet/atoms/mapped'
 end
 

--- a/lib/parslet/atoms/dsl.rb
+++ b/lib/parslet/atoms/dsl.rb
@@ -106,4 +106,13 @@ module Parslet::Atoms::DSL
   def capture(name)
     Parslet::Atoms::Capture.new(self, name)
   end
+  
+  # Applies a function to a parse result.
+  # 
+  #   str('foo')                                   # will return 'foo', 
+  #   str('foo').map(lambda { |x| x.to_s.upcase }) # will return 'FOO'
+  # 
+  def map(f)
+    Parslet::Atoms::Mapped.new(self, f)
+  end
 end

--- a/lib/parslet/atoms/mapped.rb
+++ b/lib/parslet/atoms/mapped.rb
@@ -1,0 +1,26 @@
+# Applies a function on a parse result to influence tree construction. 
+#
+# Example: 
+#
+#   str('foo')                                   # will return 'foo', 
+#   str('foo').map(lambda { |x| x.to_s.upcase }) # will return 'FOO'
+#
+class Parslet::Atoms::Mapped < Parslet::Atoms::Base
+  attr_reader :parslet, :f
+  def initialize(parslet, f)
+    super()
+
+    @parslet, @f = parslet, f
+  end
+  
+  def apply(source, context, consume_all)
+    success, value = result = parslet.apply(source, context, consume_all)
+
+    return result unless success
+    succ(f.call(value))
+  end
+  
+  def to_s_inner(prec)
+    parslet.to_s(prec)
+  end
+end

--- a/spec/parslet/atoms/mapped_spec.rb
+++ b/spec/parslet/atoms/mapped_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Parslet::Atoms::Mapped do
+  include Parslet
+
+  describe "map" do
+    it "maps over the parse result" do
+      str('a').map(lambda { |x| x.to_s.upcase }).parse('a').should == 'A'
+    end
+    
+    it "composes maps" do
+      int = match('[0-9]').repeat(1).as(:int).map(lambda { |x| x[:int].to_s.to_i })
+      date = (int.as(:year) >> str('-') >> int.as(:month) >> str('-') >> int.as(:day)).map(lambda { |x| DateTime.new(x[1][:year], x[3][:month], x[5][:day]) })
+      date.parse('2000-01-01').should == DateTime.new(2000,1,1)
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability to map over parse results. This is especially useful for parsing integers into Ruby `Fixnum`s, or composing integers together to form `DateTime`s.

Unfortunately, the mapping function currently needs to be aware of the internal structure of Parslet's parse tree. That could be fixed, but I imagine it's not easy to do. I'm mostly leaving this here as a proof of concept - I don't expect this to be merged as-is.
