### PR TITLE
fix #151 

### DIFF
--- a/lib/parslet.rb
+++ b/lib/parslet.rb
@@ -55,13 +55,13 @@ module Parslet
   
   # Raised when the parse failed to match. It contains the message that should
   # be presented to the user. More details can be extracted from the
-  # exceptions #cause member: It contains an instance of {Parslet::Cause} that
+  # exceptions #parse_failure_cause member: It contains an instance of {Parslet::Cause} that
   # stores all the details of your failed parse in a tree structure. 
   #
   #   begin
   #     parslet.parse(str)
   #   rescue Parslet::ParseFailed => failure
-  #     puts failure.cause.ascii_tree
+  #     puts failure.parse_failure_cause.ascii_tree
   #   end
   #
   # Alternatively, you can just require 'parslet/convenience' and call the
@@ -72,15 +72,15 @@ module Parslet
   #   parslet.parse_with_debug(str)
   #
   class ParseFailed < StandardError
-    def initialize(message, cause=nil)
+    def initialize(message, parse_failure_cause=nil)
       super(message)
-      @cause = cause
+      @parse_failure_cause = parse_failure_cause
     end
     
     # Why the parse failed. 
     #
     # @return [Parslet::Cause]
-    attr_reader :cause 
+    attr_reader :parse_failure_cause
   end
   
   module ClassMethods

--- a/lib/parslet/convenience.rb
+++ b/lib/parslet/convenience.rb
@@ -5,7 +5,7 @@ class Parslet::Atoms::Base
   #    begin
   #      tree = parser.parse('something')
   #    rescue Parslet::ParseFailed => error
-  #      puts parser.cause.ascii_tree
+  #      puts parser.parse_failure_cause.ascii_tree
   #    end
   #
   # into a convenient method.
@@ -27,7 +27,7 @@ class Parslet::Atoms::Base
   def parse_with_debug str, opts={}
     parse str, opts
   rescue Parslet::ParseFailed => error
-    puts error.cause.ascii_tree
+    puts error.parse_failure_cause.ascii_tree
   end
 
 end

--- a/lib/parslet/rig/rspec.rb
+++ b/lib/parslet/rig/rspec.rb
@@ -9,7 +9,7 @@ RSpec::Matchers.define(:parse) do |input, opts|
         block.call(result) : 
         (as == result || as.nil?)
     rescue Parslet::ParseFailed => ex
-      trace = ex.cause.ascii_tree if opts && opts[:trace]
+      trace = ex.parse_failure_cause.ascii_tree if opts && opts[:trace]
       false
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ def catch_failed_parse
     yield
   rescue Parslet::ParseFailed => exception
   end
-  exception.cause
+  exception.parse_failure_cause
 end
 
 def slet name, &block

--- a/website/build/get-started.html
+++ b/website/build/get-started.html
@@ -130,7 +130,7 @@ grammar terminates, since in a way, it is like a normal program.</p>
   
     mini.parse(str)
   rescue Parslet::ParseFailed =&gt; failure
-    puts failure.cause.ascii_tree
+    puts failure.parse_failure_cause.ascii_tree
   end
 
   parse "1 + 2 + 3"  # =&gt; "1 + 2 + 3"@0
@@ -156,7 +156,7 @@ Expected one of [SUM, INTEGER] at line 1 char 1.
 <p>This is what parslet calls an <code>#error_tree</code>. Not only the output of
 your parser, but also its grammar is constructed like a tree. When things go
 wrong, every branch of the tree has its own reasons for not accepting a given
-input. The <code>#cause</code> method returns those reasons.</p>
+input. The <code>#parse_failure_cause</code> method returns those reasons.</p>
 <p>Our grammar has essentially two branches, <code>SUM</code> and
 <code>INTEGER</code>. Can you see why all rules expect a number as the first
 character?</p>

--- a/website/build/tricks.html
+++ b/website/build/tricks.html
@@ -118,7 +118,7 @@ handling code that will help you out:</p>
   begin
     parser.parse('bar')
   rescue Parslet::ParseFailed =&gt; error
-    puts error.cause.ascii_tree
+    puts error.parse_failure_cause.ascii_tree
   end
 </code></pre>
 <p>This should print something akin to:</p>
@@ -149,7 +149,7 @@ grammar structure:</p>
   begin
     P.new.parse('barbaz')
   rescue Parslet::ParseFailed =&gt; error
-    puts error.cause.ascii_tree
+    puts error.parse_failure_cause.ascii_tree
   end
 </code></pre>
 <p>Outputs:</p>
@@ -174,7 +174,7 @@ with the &#8216;deepest error position&#8217; engine:</p>
   begin
     P.new.parse('barbaz', reporter: Parslet::ErrorReporter::Deepest.new)
   rescue Parslet::ParseFailed =&gt; error
-    puts error.cause.ascii_tree
+    puts error.parse_failure_cause.ascii_tree
   end
 </code></pre>
 <p>Outputs:</p>

--- a/website/source/get-started.html.textile
+++ b/website/source/get-started.html.textile
@@ -118,7 +118,7 @@ Here's the full parser:
   
     mini.parse(str)
   rescue Parslet::ParseFailed => failure
-    puts failure.cause.ascii_tree
+    puts failure.parse_failure_cause.ascii_tree
   end
 
   parse "1 + 2 + 3"  # => "1 + 2 + 3"@0
@@ -148,7 +148,7 @@ Expected one of [SUM, INTEGER] at line 1 char 1.
 This is what parslet calls an <code>#error_tree</code>. Not only the output of
 your parser, but also its grammar is constructed like a tree. When things go
 wrong, every branch of the tree has its own reasons for not accepting a given
-input. The <code>#cause</code> method returns those reasons.
+input. The <code>#parse_failure_cause</code> method returns those reasons.
 
 Our grammar has essentially two branches, <code>SUM</code> and
 <code>INTEGER</code>. Can you see why all rules expect a number as the first

--- a/website/source/tricks.html.textile
+++ b/website/source/tricks.html.textile
@@ -105,7 +105,7 @@ handling code that will help you out:
   begin
     parser.parse('bar')
   rescue Parslet::ParseFailed => error
-    puts error.cause.ascii_tree
+    puts error.parse_failure_cause.ascii_tree
   end
 </code></pre>
 
@@ -145,7 +145,7 @@ grammar structure:
   begin
     P.new.parse('barbaz')
   rescue Parslet::ParseFailed => error
-    puts error.cause.ascii_tree
+    puts error.parse_failure_cause.ascii_tree
   end
 </code></pre>
 
@@ -174,7 +174,7 @@ with the 'deepest error position' engine:
   begin
     P.new.parse('barbaz', reporter: Parslet::ErrorReporter::Deepest.new)
   rescue Parslet::ParseFailed => error
-    puts error.cause.ascii_tree
+    puts error.parse_failure_cause.ascii_tree
   end
 </code></pre>
 


### PR DESCRIPTION
I think the name of `Parslet::Cause` has no problem, so I keep it.
