### PR TITLE
Silence interpreter warnings

### DIFF
--- a/lib/parslet.rb
+++ b/lib/parslet.rb
@@ -100,6 +100,7 @@ module Parslet
     #   end
     #
     def rule(name, opts={}, &definition)
+      undef_method name if method_defined? name
       define_method(name) do
         @rules ||= {}     # <name, rule> memoization
         return @rules[name] if @rules.has_key?(name)

--- a/lib/parslet/parser.rb
+++ b/lib/parslet/parser.rb
@@ -51,6 +51,7 @@ class Parslet::Parser < Parslet::Atoms::Base
     #   end
     #
     def root(name)
+      undef_method :root if method_defined? :root
       define_method(:root) do
         self.send(name)
       end

--- a/lib/parslet/rig/rspec.rb
+++ b/lib/parslet/rig/rspec.rb
@@ -45,8 +45,8 @@ RSpec::Matchers.define(:parse) do |input, opts|
 
   # NOTE: This has a nodoc tag since the rdoc parser puts this into 
   # Object, a thing I would never allow. 
-  chain :as do |expected_output=nil, &block|
+  chain :as do |expected_output=nil, &my_block|
     as = expected_output
-    block = block
+    block = my_block
   end
 end


### PR DESCRIPTION
This is a very low-priority PR. I have no strong feelings about it. Thanks for
the wonderful library!

I'm currently using the version of this library at

    a80c077755ef5d79c297421299230a3465b86f32

which is the current HEAD of master. I noticed some warnings emitted when I ran
the specs for my project. I decided to run Parslet's specs with

    rspec --warnings

and silenced all the warnings that are emitted from files in `/lib`. I left the
warnings in `/spec`, since I think those are related to RSpec "should" syntax.