### PR TITLE
Fix character class typo in get-started example

### DIFF
--- a/website/source/get-started.html.textile
+++ b/website/source/get-started.html.textile
@@ -221,7 +221,7 @@ class MiniP < Parslet::Parser
 
   # Things
   rule(:integer)    { match('[0-9]').repeat(1).as(:int) >> space? }
-  rule(:identifier) { match['a-z'].repeat(1) }
+  rule(:identifier) { match['[a-z]'].repeat(1) }
   rule(:operator)   { match('[+]') >> space? }
   
   # Grammar parts
@@ -307,7 +307,7 @@ class MiniP < Parslet::Parser
 
   # Things
   rule(:integer)    { match('[0-9]').repeat(1).as(:int) >> space? }
-  rule(:identifier) { match['a-z'].repeat(1) }
+  rule(:identifier) { match['[a-z]'].repeat(1) }
   rule(:operator)   { match('[+]') >> space? }
   
   # Grammar parts


### PR DESCRIPTION
Encountered a small typo and thought I'd fix it. Cheers.