### PR TITLE
Unable to run under ruby 1.9.3 

### DIFF
--- a/lib/parslet/transform.rb
+++ b/lib/parslet/transform.rb
@@ -140,7 +140,7 @@ class Parslet::Transform
     end
   end
   
-  def initialize(raise_on_unmatch: false, &block) 
+  def initialize(raise_on_unmatch=false, &block) 
     @raise_on_unmatch = raise_on_unmatch
     @rules = []
     


### PR DESCRIPTION
Looks like a ruby 2 construct has snuck in here?

This corrects it.