### PR TITLE
Performance improvements

### DIFF
--- a/lib/parslet/atoms.rb
+++ b/lib/parslet/atoms.rb
@@ -3,18 +3,17 @@
 #
 module Parslet::Atoms
   # The precedence module controls parenthesis during the #inspect printing
-  # of parslets. It is not relevant to other aspects of the parsing. 
+  # of parslets. It is not relevant to other aspects of the parsing.
   #
   module Precedence
-    prec = 0
-    BASE       = (prec+=1)    # everything else
-    LOOKAHEAD  = (prec+=1)    # &SOMETHING
-    REPETITION = (prec+=1)    # 'a'+, 'a'?
-    SEQUENCE   = (prec+=1)    # 'a' 'b'
-    ALTERNATE  = (prec+=1)    # 'a' | 'b'
-    OUTER      = (prec+=1)    # printing is done here.
+    BASE       = 1    # everything else
+    LOOKAHEAD  = 2    # &SOMETHING
+    REPETITION = 3    # 'a'+, 'a'?
+    SEQUENCE   = 4    # 'a' 'b'
+    ALTERNATE  = 5    # 'a' | 'b'
+    OUTER      = 6    # printing is done here.
   end
-  
+
   require 'parslet/atoms/can_flatten'
   require 'parslet/atoms/context'
   require 'parslet/atoms/dsl'
@@ -33,4 +32,3 @@ module Parslet::Atoms
   require 'parslet/atoms/scope'
   require 'parslet/atoms/infix'
 end
-

--- a/lib/parslet/atoms/alternative.rb
+++ b/lib/parslet/atoms/alternative.rb
@@ -19,7 +19,6 @@ class Parslet::Atoms::Alternative < Parslet::Atoms::Base
     super()
     
     @alternatives = alternatives
-    @error_msg = "Expected one of #{alternatives.inspect}"
   end
 
   #---
@@ -29,7 +28,11 @@ class Parslet::Atoms::Alternative < Parslet::Atoms::Base
   def |(parslet)
     self.class.new(*@alternatives + [parslet])
   end
-  
+
+  def error_msg
+    @error_msg ||= "Expected one of #{alternatives.inspect}"
+  end
+
   def try(source, context, consume_all)
     errors = alternatives.map { |a|
       success, value = result = a.apply(source, context, consume_all)
@@ -40,7 +43,7 @@ class Parslet::Atoms::Alternative < Parslet::Atoms::Base
     }
     
     # If we reach this point, all alternatives have failed. 
-    context.err(self, source, @error_msg, errors)
+    context.err(self, source, error_msg, errors)
   end
 
   precedence ALTERNATE

--- a/lib/parslet/atoms/lookahead.rb
+++ b/lib/parslet/atoms/lookahead.rb
@@ -14,9 +14,11 @@ class Parslet::Atoms::Lookahead < Parslet::Atoms::Base
     # Model positive and negative lookahead by testing this flag.
     @positive = positive
     @bound_parslet = bound_parslet
-    
-    @error_msgs = {
-      :positive => ["Input should start with ", bound_parslet], 
+  end
+
+  def error_msgs
+    @error_msgs ||= {
+      :positive => ["Input should start with ", bound_parslet],
       :negative => ["Input should not start with ", bound_parslet]
     }
   end
@@ -29,10 +31,10 @@ class Parslet::Atoms::Lookahead < Parslet::Atoms::Base
     
     if positive
       return succ(nil) if success
-      return context.err_at(self, source, @error_msgs[:positive], error_pos)
+      return context.err_at(self, source, error_msgs[:positive], error_pos)
     else
       return succ(nil) unless success
-      return context.err_at(self, source, @error_msgs[:negative], error_pos)
+      return context.err_at(self, source, error_msgs[:negative], error_pos)
     end
     
   # This is probably the only parslet that rewinds its input in #try.
@@ -43,8 +45,8 @@ class Parslet::Atoms::Lookahead < Parslet::Atoms::Base
   
   precedence LOOKAHEAD
   def to_s_inner(prec)
-    char = positive ? '&' : '!'
-    
-    "#{char}#{bound_parslet.to_s(prec)}"
+    @char = positive ? '&' : '!'
+
+    "#{@char}#{bound_parslet.to_s(prec)}"
   end
 end

--- a/lib/parslet/atoms/re.rb
+++ b/lib/parslet/atoms/re.rb
@@ -14,9 +14,12 @@ class Parslet::Atoms::Re < Parslet::Atoms::Base
 
     @match = match.to_s
     @re    = Regexp.new(self.match, Regexp::MULTILINE)
-    @error_msgs = {
-      :premature  => "Premature end of input", 
-      :failed     => "Failed to match #{match.inspect[1..-2]}"
+  end
+
+  def error_msgs
+    @error_msgs ||= {
+      premature: 'Premature end of input',
+      failed: "Failed to match #{match.inspect[1..-2]}"
     }
   end
 
@@ -24,11 +27,11 @@ class Parslet::Atoms::Re < Parslet::Atoms::Base
     return succ(source.consume(1)) if source.matches?(@re)
     
     # No string could be read
-    return context.err(self, source, @error_msgs[:premature]) \
+    return context.err(self, source, error_msgs[:premature]) \
       if source.chars_left < 1
         
     # No match
-    return context.err(self, source, @error_msgs[:failed])
+    return context.err(self, source, error_msgs[:failed])
   end
 
   def to_s_inner(prec)

--- a/lib/parslet/atoms/repetition.rb
+++ b/lib/parslet/atoms/repetition.rb
@@ -17,11 +17,15 @@ class Parslet::Atoms::Repetition < Parslet::Atoms::Base
 
 
     @parslet = parslet
-    @min, @max = min, max
+    @min = min
+    @max = max
     @tag = tag
-    @error_msgs = {
-      :minrep  => "Expected at least #{min} of #{parslet.inspect}", 
-      :unconsumed => "Extra input after last repetition"
+  end
+
+  def error_msgs
+    @error_msgs ||= {
+      minrep: "Expected at least #{min} of #{parslet.inspect}",
+      unconsumed: 'Extra input after last repetition'
     }
   end
   
@@ -51,7 +55,7 @@ class Parslet::Atoms::Repetition < Parslet::Atoms::Base
     return context.err_at(
       self, 
       source, 
-      @error_msgs[:minrep], 
+      error_msgs[:minrep],
       start_pos, 
       [break_on]) if occ < min
       
@@ -66,7 +70,7 @@ class Parslet::Atoms::Repetition < Parslet::Atoms::Base
     return context.err(
       self, 
       source, 
-      @error_msgs[:unconsumed], 
+      error_msgs[:unconsumed], 
       [break_on]) if consume_all && source.chars_left>0
       
     return succ(accum)

--- a/lib/parslet/atoms/sequence.rb
+++ b/lib/parslet/atoms/sequence.rb
@@ -10,8 +10,11 @@ class Parslet::Atoms::Sequence < Parslet::Atoms::Base
     super()
 
     @parslets = parslets
-    @error_msgs = {
-      :failed  => "Failed to match sequence (#{self.inspect})"
+  end
+
+  def error_msgs
+    @error_msgs ||= {
+      failed: "Failed to match sequence (#{inspect})"
     }
   end
   
@@ -29,7 +32,7 @@ class Parslet::Atoms::Sequence < Parslet::Atoms::Base
       success, value = p.apply(source, context, child_consume_all) 
 
       unless success
-        return context.err(self, source, @error_msgs[:failed], [value]) 
+        return context.err(self, source, error_msgs[:failed], [value])
       end
 
       result[idx+1] = value

--- a/lib/parslet/atoms/str.rb
+++ b/lib/parslet/atoms/str.rb
@@ -12,9 +12,12 @@ class Parslet::Atoms::Str < Parslet::Atoms::Base
     @str = str.to_s
     @pat = Regexp.new(Regexp.escape(str))
     @len = str.size
-    @error_msgs = {
-      :premature  => "Premature end of input", 
-      :failed     => "Expected #{str.inspect}, but got "
+  end
+
+  def error_msgs
+    @error_msgs ||= {
+      premature: 'Premature end of input',
+      failed: "Expected #{str.inspect}, but got "
     }
   end
   
@@ -22,14 +25,14 @@ class Parslet::Atoms::Str < Parslet::Atoms::Base
     return succ(source.consume(@len)) if source.matches?(@pat)
     
     # Input ending early:
-    return context.err(self, source, @error_msgs[:premature]) \
+    return context.err(self, source, error_msgs[:premature]) \
       if source.chars_left<@len
     
     # Expected something, but got something else instead:  
     error_pos = source.pos  
     return context.err_at(
       self, source, 
-      [@error_msgs[:failed], source.consume(@len)], error_pos) 
+      [error_msgs[:failed], source.consume(@len)], error_pos) 
   end
   
   def to_s_inner(prec)


### PR DESCRIPTION
A couple of optimizations that seem to pretty dramatically improve performance.  One of the problems I encountered with a fairly complex parser was that it was spending a lot of time formatting error messages in Atom constructors that were never used during successful parsing.  Because the error messages can recursively include string representations of other Atoms, this got expensive fast.  By moving them out into their own methods, we can delay evaluation until they are needed and also memoize the result so we only do it once.