### PR TITLE
Spec fixes for Ruby 2.5, 2.6

### DIFF
--- a/example/mathn.rb
+++ b/example/mathn.rb
@@ -38,7 +38,10 @@ attempt_parse
 puts 'it terminates before we require mathn'
 
 puts "requiring mathn now"
-require 'mathn'
+# mathn was deprecated as of Ruby 2.5
+if RUBY_VERSION.gsub(/[^\d]/, '').to_i < 250
+  require 'mathn'
+end
 puts "and trying again (will hang without the fix)"
 attempt_parse # but it doesn't terminate after requiring mathn
 puts "okay!"

--- a/spec/parslet/slice_spec.rb
+++ b/spec/parslet/slice_spec.rb
@@ -112,14 +112,7 @@ describe Parslet::Slice do
           s.to_i.should == 1234
         end 
         it "should fail when Integer would fail on a string" do
-           # Ruby 2.6 will call `#to_i` if `#to_int` fails
-           if RUBY_VERSION.gsub(/[^\d]/, '').to_i >= 260
-             Integer(slice).should == 0
-           else
-             lambda do
-               Integer(slice)
-             end.should raise_error(ArgumentError, /invalid value/)
-           end
+          lambda { Integer(slice.to_s) }.should raise_error(ArgumentError, /invalid value/)
         end
         it "should turn into zero when a string would" do
           slice.to_i.should == 0

--- a/spec/parslet/slice_spec.rb
+++ b/spec/parslet/slice_spec.rb
@@ -112,8 +112,15 @@ describe Parslet::Slice do
           s.to_i.should == 1234
         end 
         it "should fail when Integer would fail on a string" do
-          lambda { Integer(slice) }.should raise_error(ArgumentError, /invalid value/)
-        end 
+           # Ruby 2.6 will call `#to_i` if `#to_int` fails
+           if RUBY_VERSION.gsub(/[^\d]/, '').to_i >= 260
+             Integer(slice).should == 0
+           else
+             lambda do
+               Integer(slice)
+             end.should raise_error(ArgumentError, /invalid value/)
+           end
+        end
         it "should turn into zero when a string would" do
           slice.to_i.should == 0
         end 


### PR DESCRIPTION
Ran this on `2.6.1`, had 2 specs fail due to the Ruby version:

1. `mathn` is deprecated since 2.5 - this fixes https://github.com/kschiess/parslet/pull/192
2. `Integer()` calls `to_i` if `to_int` fails, as of 2.6 - see https://github.com/ruby/ruby/blob/ruby_2_6/spec/ruby/core/kernel/Integer_spec.rb#L22-L36