### PR TITLE
Allow 'match' to match any regular expression and parse multiple characters at once

### DIFF
--- a/example/iban.rb
+++ b/example/iban.rb
@@ -1,0 +1,32 @@
+# A small example on how to parse common types of comments. The example
+# started out with parser code from Stephen Waits. 
+
+$:.unshift File.dirname(__FILE__) + "/../lib"
+
+require 'pp'
+require 'parslet'
+require 'parslet/convenience'
+
+class ALanguage < Parslet::Parser
+  root(:lines)
+  
+  rule(:lines) { line.repeat }
+  rule(:line) { iban >> newline.maybe }
+  rule(:newline) { str("\n") }
+  
+  rule(:iban) { match(/[A-Z]{2}\d\d( [A-Z\d]{4}){1,6}( [A-Z\d]{1,4})/i).as(:iban) }
+end
+
+valid = [
+  'NO93 8601 1117 947',
+  'nl91 abna 0417 1643 00',
+  'MT84 MALT 0110 0001 2345 MTLC AST0 01S'
+].join("\n")
+
+invalid = [
+  'NO93 8601 1117 947',
+  'foobar'
+].join("\n")
+
+pp ALanguage.new.parse_with_debug(valid)
+pp ALanguage.new.parse_with_debug(invalid)

--- a/example/output/iban.out
+++ b/example/output/iban.out
@@ -1,0 +1,7 @@
+[{:iban=>"NO93 8601 1117 947"@0},
+ {:iban=>"nl91 abna 0417 1643 00"@19},
+ {:iban=>"MT84 MALT 0110 0001 2345 MTLC AST0 01S"@42}]
+Extra input after last repetition at line 2 char 1.
+`- Failed to match sequence (IBAN NEWLINE?) at line 2 char 1.
+   `- Failed to match (?i-mx:[A-Z]{2}\\d\\d( [A-Z\\d]{4}){1,6}( [A-Z\\d]{1,4})) at line 2 char 1.
+nil

--- a/lib/parslet/atoms/re.rb
+++ b/lib/parslet/atoms/re.rb
@@ -13,7 +13,11 @@ class Parslet::Atoms::Re < Parslet::Atoms::Base
     super()
 
     @match = match.to_s
-    @re    = Regexp.new(self.match, Regexp::MULTILINE)
+    @re = if match.kind_of?(Regexp)
+            match
+          else
+            Regexp.new(self.match, Regexp::MULTILINE)
+          end
   end
 
   def error_msgs
@@ -24,8 +28,10 @@ class Parslet::Atoms::Re < Parslet::Atoms::Base
   end
 
   def try(source, context, consume_all)
-    return succ(source.consume(1)) if source.matches?(@re)
-    
+    slice = source.scan(@re)
+
+    return succ(slice) if slice
+
     # No string could be read
     return context.err(self, source, error_msgs[:premature]) \
       if source.chars_left < 1

--- a/lib/parslet/source.rb
+++ b/lib/parslet/source.rb
@@ -39,14 +39,16 @@ module Parslet
     # input. 
     #
     def consume(n)
-      position = self.pos
-      slice_str = @str.scan(@re_cache[n])
-      slice = Parslet::Slice.new(
-        position, 
-        slice_str,
-        @line_cache)
+      scan(@re_cache[n])
+    end
 
-      return slice
+    # Consumes given pattern from the input, returning matching characters as
+    # a slice of the input.
+    #
+    def scan(pattern)
+      position = self.pos
+      slice_str = @str.scan(pattern)
+      Parslet::Slice.new(position, slice_str, @line_cache) if slice_str
     end
     
     # Returns how many chars remain in the input. 

--- a/spec/parslet/atoms/re_spec.rb
+++ b/spec/parslet/atoms/re_spec.rb
@@ -9,6 +9,10 @@ describe Parslet::Atoms::Re do
     end 
     it "should allow match[str] form" do
       match['a'].should be_a(Parslet::Atoms::Re)
-    end 
+    end
+
+    it "should allow match(regexp) form" do
+      match(/foobar/).should be_a(Parslet::Atoms::Re)
+    end
   end
 end


### PR DESCRIPTION
Parslet is a great library (thanks for your work!) but it's also VERY memory hungry. While using parslet for parsing bank account statements in mt940 format I observed memory usage of up to 1,6 GB for an input file of less than 3 MB.

One of the problems is the overhead of having to use many atoms to describe something that could easily be combined with a single regular expression. I'm not sure why you've chosen to match only a single character at a time with `match` but it makes things unnecessarily complex.

This PR extends the `match` atom by accepting any regular expression and removing the single character limit. 

When I simplified the mt940 parser with this, memory usage dropped by 66%.