### PR TITLE
Use Github Actions for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - head
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+    continue-on-error: ${{ matrix.ruby == 'head' }}
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: |
+          bundle exec rspec --force-color


### PR DESCRIPTION
This also updates the Ruby versions tested against.

Travis CI's open source support is deprecated and jobs stay in the queue significantly longer now.

Github Actions is faster, still free, and built-in to Github.

Here's a passing build on my fork: https://github.com/mlarraz/parslet/actions/runs/1098326563

Note that the build won't trigger on the base repo until this PR is merged, so keeping around Travis until then.