### PR TITLE
Fixes needed for scanning of large files

### DIFF
--- a/lib/parslet/atoms/base.rb
+++ b/lib/parslet/atoms/base.rb
@@ -28,6 +28,7 @@ class Parslet::Atoms::Base
       io : 
       Parslet::Source.new(io)
 
+    starting_position = source.bytepos
     # Try to cheat. Assuming that we'll be able to parse the input, don't 
     # run error reporting code. 
     success, value = setup_and_apply(source, nil, !options[:prefix])
@@ -39,7 +40,7 @@ class Parslet::Atoms::Base
       # Cheating has not paid off. Now pay the cost: Rerun the parse,
       # gathering error information in the process.
       reporter = options[:reporter] || Parslet::ErrorReporter::Tree.new
-      source.bytepos = 0
+      source.bytepos = starting_position
       success, value = setup_and_apply(source, reporter, !options[:prefix])
       
       fail "Assertion failed: success was true when parsing with reporter" \

--- a/lib/parslet/source.rb
+++ b/lib/parslet/source.rb
@@ -49,6 +49,17 @@ module Parslet
       return slice
     end
     
+    def consume_until(pattern)
+      position = self.pos
+      slice_str = @str.scan_until(pattern)
+      slice = Parslet::Slice.new(
+        position, 
+        slice_str,
+        @line_cache)
+
+      return slice
+    end
+    
     # Returns how many chars remain in the input. 
     #
     def chars_left

--- a/spec/parslet/atoms/base_spec.rb
+++ b/spec/parslet/atoms/base_spec.rb
@@ -69,6 +69,18 @@ describe Parslet::Atoms::Base do
     end
   end
   
+  context "when the parse fails, for a partially consumed stream, the exception" do
+    it "should contain a string" do
+      begin
+        source = Parslet::Source.new("foobar")
+        source.consume(3)
+        Parslet.str('foo').parse(source)
+      rescue Parslet::ParseFailed => ex
+        ex.message.should be_kind_of(String)
+      end
+    end 
+  end
+
   context "when the parse fails, the exception" do
     it "should contain a string" do
       begin

--- a/spec/parslet/source_spec.rb
+++ b/spec/parslet/source_spec.rb
@@ -139,8 +139,8 @@ describe Parslet::Source do
     
   end
   
-  describe "reading encoded input" do
-    let(:source) { described_class.new("éö変わる") }
+  describe "consume_until" do
+    let(:source) { described_class.new("") }
 
     def r str
       Regexp.new(Regexp.escape(str))
@@ -163,6 +163,20 @@ describe Parslet::Source do
       source.consume(2)
       source.chars_left.should == 0
       source.chars_left.should == 0
+    end 
+  end
+
+  describe "reading encoded input" do
+    let(:source) { described_class.new("pre b b a") }
+
+    def r str
+      Regexp.new(Regexp.escape(str))
+    end
+  
+    it "should read characters, not bytes" do
+      source.consume_until(/b/).should == "pre b"
+      source.pos.charpos.should == 5
+      source.bytepos.should == 5
     end 
   end
 end


### PR DESCRIPTION
Fixes to allow my use case of parsing 500mb+ file, with huge blocks of content that do not need parsing, but was taking forever to do without.
 
- Reparse for error logging no longer resets to 0, it returns to the starting position. This is helpful for parsing lots of entries from a stream.
- Adds `Source#consume_until` which allows me to scan large blocks of code looking for an end symbol.