### PR TITLE
specify required Ruby version

### DIFF
--- a/parslet.gemspec
+++ b/parslet.gemspec
@@ -12,5 +12,6 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.rdoc_options = ['--main', 'README']
   s.require_paths = ['lib']
+  s.required_ruby_version = '>= 2.5'
   s.summary = 'Parser construction library with great error reporting in Ruby.'
 end


### PR DESCRIPTION
Currently, parslet is tested on Ruby 2.5 or higher so I think required Ruby version should be specified.
This PR to add `required_ruby_version` to the gemspec.